### PR TITLE
게시판 api만들기 - Data Rest 적용 및 테스트 정의

### DIFF
--- a/webserver-project-board/build.gradle
+++ b/webserver-project-board/build.gradle
@@ -19,16 +19,19 @@ repositories {
 }
 
 dependencies {
+
+    //dependencies 추가(JPA, H2, mysql driver)
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    //dependencies 추가(JPA, H2, mysql driver)
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/webserver-project-board/src/main/java/com/webserver/projectboard/repository/ArticleCommentRepository.java
+++ b/webserver-project-board/src/main/java/com/webserver/projectboard/repository/ArticleCommentRepository.java
@@ -2,9 +2,9 @@ package com.webserver.projectboard.repository;
 
 import com.webserver.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
-
-
 
 }

--- a/webserver-project-board/src/main/java/com/webserver/projectboard/repository/ArticleCommentRepository.java
+++ b/webserver-project-board/src/main/java/com/webserver/projectboard/repository/ArticleCommentRepository.java
@@ -6,5 +6,4 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
-
 }

--- a/webserver-project-board/src/main/java/com/webserver/projectboard/repository/ArticleRepository.java
+++ b/webserver-project-board/src/main/java/com/webserver/projectboard/repository/ArticleRepository.java
@@ -2,8 +2,9 @@ package com.webserver.projectboard.repository;
 
 import com.webserver.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
-
 
 }

--- a/webserver-project-board/src/main/resources/application.yaml
+++ b/webserver-project-board/src/main/resources/application.yaml
@@ -22,4 +22,8 @@ spring:
       hibernate.default_batch_fetch_size: 100
       hibernate.globally_quoted_identifiers: ture
   sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
+
 

--- a/webserver-project-board/src/test/java/com/webserver/projectboard/controller/DataRestTest.java
+++ b/webserver-project-board/src/test/java/com/webserver/projectboard/controller/DataRestTest.java
@@ -1,0 +1,40 @@
+package com.webserver.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data Rest - API Test")
+@Transactional  //rollback상태로 transaction이 묶인다.
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired  MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] article comment select")
+    @Test
+    void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        //Given
+
+        //When&Then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 API들의 존재 여부만 체크할 수 있도록 통합테스트 작성함.